### PR TITLE
Change themes.js to local-themes due to magento overwriting during up…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ $ npm install
 
 ## Configuration
 
-Check or set theme configuration in the `dev/tools/grunt/configs/themes.js`
+Copy the contents of `themes.js` into `local-themes.js` in the `dev/tools/grunt/configs/` directory.
+
 
 ```
 module.exports = {

--- a/dev/tools/gulp/matchTheme.js
+++ b/dev/tools/gulp/matchTheme.js
@@ -8,7 +8,7 @@
  * @terms of use http://www.absolutewebservices.com/terms-of-use/
  */
 
-const themesConfig = require('../grunt/configs/themes');
+const themesConfig = require('../grunt/configs/local-themes');
 
 const packages = Object.keys(themesConfig);
 

--- a/dev/tools/gulp/paths.js
+++ b/dev/tools/gulp/paths.js
@@ -9,7 +9,7 @@
  */
 
 const args = require('./args');
-const themesConfig = require('../grunt/configs/themes');
+const themesConfig = require('../grunt/configs/local-themes');
 const matchTheme = require('./matchTheme');
 const devArgs = require('./constants/devArgs');
 const commands = require('./constants/commands');


### PR DESCRIPTION
Since magento might update themes.js on future updates its suggested to copy your file and make a local-themes.js file. as written in the documentation. 

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html