### PR TITLE
Suggest to use composer require --dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add repository's path to the `composer.json`
 Run
 
 ```
-$ composer require bobmotor/magento-2-gulp
+$ composer require --dev bobmotor/magento-2-gulp
 ```
 
 Rename the following files in your project root directory


### PR DESCRIPTION
Since this is a development tool, it should be included as a dev dependency, right?