### PR TITLE
Critical css

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Rename `dev/tools/gulp/configs/local.js.sample-aws` to `dev/tools/gulp/configs/l
 
 ```
 module.exports = {
-    hostname: 'hostname'
+    hostname: 'hostname',
+    generic: 'loc',
+    useHttp2: false
 };
 ```
 
@@ -113,7 +115,9 @@ Example:
 
 ```
 module.exports = {
-    hostname: 'capezio'
+    hostname: 'capezio',,
+    generic: 'loc',
+    useHttp2: true
 };
 ```
 
@@ -121,8 +125,8 @@ If you need to configure `BrowserSync` use the `dev/tools/gulp/configs/bsConfig.
 
 ```
 module.exports = {
-    proxy: `http://${localConfig.hostname}.loc/`,
-    host: `${localConfig.hostname}.loc`,
+    proxy: `${ptotocol}://${localConfig.hostname}.${localConfig.generic}/`,
+    host: `${localConfig.hostname}.${localConfig.generic}`,
     tunnel: `${localConfig.hostname}`,
     open: false
 };
@@ -132,8 +136,8 @@ Example:
 
 ```
 module.exports = {
-    proxy: `http://${localConfig.hostname}.loc/`,
-    host: `${localConfig.hostname}.loc`,
+    proxy: `${ptotocol}://${localConfig.hostname}.${localConfig.generic}/`,
+    host: `${localConfig.hostname}.${localConfig.generic}`,
     tunnel: `${localConfig.hostname}`,
     open: true
 };
@@ -144,7 +148,7 @@ To configure your desired screen size for the critical path use the `dev/tools/g
 ```
 module.exports = {
     out: 'critical.css',
-    url: `https://${localConfig.hostname}.loc/`,
+    url: `${ptotocol}://${localConfig.hostname}.${localConfig.generic}/`,
     width: 1920,
     height: 900,
     forceExclude: [/\[data-role=main-css-loader]/]
@@ -156,7 +160,7 @@ Example:
 ```
 module.exports = {
     out: 'critical.css',
-    url: `https://${localConfig.hostname}.loc/`,
+    url: `${ptotocol}://${localConfig.hostname}.${localConfig.generic}/`,
     width: 1920,
     height: 250,
     forceExclude: [/\[data-role=main-css-loader]/]

--- a/README.md
+++ b/README.md
@@ -101,13 +101,29 @@ module.exports = {
 }
 ```
 
-To configure BrowserSync set hostnames in the `dev/tools/gulp/configs/bsConfig.js`
+Rename `dev/tools/gulp/configs/local.js.sample-aws` to `dev/tools/gulp/configs/local.js` and set your `hostname` to configure `BrowserSync` and `Critical CSS` urls.
 
 ```
 module.exports = {
-    proxy: 'http://hostname.loc/',
-    host: 'hostname.loc',
-    tunnel: 'hostname',
+    hostname: 'hostname'
+};
+```
+
+Example:
+
+```
+module.exports = {
+    hostname: 'capezio'
+};
+```
+
+If you need to configure `BrowserSync` use the `dev/tools/gulp/configs/bsConfig.js`
+
+```
+module.exports = {
+    proxy: `http://${localConfig.hostname}.loc/`,
+    host: `${localConfig.hostname}.loc`,
+    tunnel: `${localConfig.hostname}`,
     open: false
 };
 ```
@@ -116,19 +132,19 @@ Example:
 
 ```
 module.exports = {
-    proxy: 'http://capezio.loc/',
-    host: 'capezio.loc',
-    tunnel: 'capezio',
-    open: false
+    proxy: `http://${localConfig.hostname}.loc/`,
+    host: `${localConfig.hostname}.loc`,
+    tunnel: `${localConfig.hostname}`,
+    open: true
 };
 ```
 
-To configure critical CSS compilation set `url` and your desired screen size in the `dev/tools/gulp/configs/criticalConfig.js`
+To configure your desired screen size for the critical path use the `dev/tools/gulp/configs/criticalConfig.js`
 
 ```
 module.exports = {
     out: 'critical.css',
-    url: 'http://hostname.loc/',
+    url: `https://${localConfig.hostname}.loc/`,
     width: 1920,
     height: 900,
     forceExclude: [/\[data-role=main-css-loader]/]
@@ -140,9 +156,9 @@ Example:
 ```
 module.exports = {
     out: 'critical.css',
-    url: 'http://capezio.loc/',
+    url: `https://${localConfig.hostname}.loc/`,
     width: 1920,
-    height: 900,
+    height: 250,
     forceExclude: [/\[data-role=main-css-loader]/]
 };
 ```
@@ -191,7 +207,7 @@ Watch styles with `livereload` (`LiveReload` browser extension should be install
 gulp watch-styles --capezio --map --live
 ```
 Creates `critical.css` from `styles-l.css` and `styles-m.css` and put it to `app/design/frontend/<VandorName>/<ThemeName>/web/css`.
-In `production` mode should be run after `php bin/magento s:s:d` (task uses `pub/static/deployed_version.txt` to create relative path from the root of the site)
+In `production` mode should be run after `php bin/magento s:s:d` (task uses `pub/static/deployed_version.txt` to create absolute path to the static files)
 ```
 gulp critical --capezio
 ```

--- a/dev/tools/gulp/configs/bsConfig.js
+++ b/dev/tools/gulp/configs/bsConfig.js
@@ -10,9 +10,11 @@
 
 const localConfig = require('./local');
 
+const ptotocol = localConfig.useHttp2 ? 'https' : 'http';
+
 module.exports = {
-    proxy: `http://${localConfig.hostname}.loc/`,
-    host: `${localConfig.hostname}.loc`,
+    proxy: `${ptotocol}://${localConfig.hostname}.${localConfig.generic}/`,
+    host: `${localConfig.hostname}.${localConfig.generic}`,
     tunnel: `${localConfig.hostname}`,
     open: false
 };

--- a/dev/tools/gulp/configs/criticalConfig.js
+++ b/dev/tools/gulp/configs/criticalConfig.js
@@ -10,10 +10,12 @@
 
 const localConfig = require('./local');
 
+const ptotocol = localConfig.useHttp2 ? 'https' : 'http';
+
 module.exports = {
     out: 'critical.css',
-    url: `https://${localConfig.hostname}.loc/`,
+    url: `${ptotocol}://${localConfig.hostname}.${localConfig.generic}/`,
     width: 1920,
-    height: 250,
+    height: 900,
     forceExclude: [/\[data-role=main-css-loader]/]
 };

--- a/dev/tools/gulp/configs/criticalConfig.js
+++ b/dev/tools/gulp/configs/criticalConfig.js
@@ -8,9 +8,11 @@
  * @terms of use http://www.absolutewebservices.com/terms-of-use/
  */
 
+const localConfig = require('./local');
+
 module.exports = {
     out: 'critical.css',
-    url: 'http://hostname.loc/',
+    url: `https://${localConfig.hostname}.loc/`,
     width: 1920,
     height: 250,
     forceExclude: [/\[data-role=main-css-loader]/]

--- a/dev/tools/gulp/configs/local.js.sample-aws
+++ b/dev/tools/gulp/configs/local.js.sample-aws
@@ -9,5 +9,7 @@
  */
 
 module.exports = {
-    hostname: 'hostname'
+    hostname: 'hostname',
+    generic: 'loc',
+    useHttp2: false
 };

--- a/dev/tools/gulp/configs/local.js.sample-aws
+++ b/dev/tools/gulp/configs/local.js.sample-aws
@@ -8,11 +8,6 @@
  * @terms of use http://www.absolutewebservices.com/terms-of-use/
  */
 
-const localConfig = require('./local');
-
 module.exports = {
-    proxy: `http://${localConfig.hostname}.loc/`,
-    host: `${localConfig.hostname}.loc`,
-    tunnel: `${localConfig.hostname}`,
-    open: false
+    hostname: 'hostname'
 };

--- a/dev/tools/gulp/loggers.js
+++ b/dev/tools/gulp/loggers.js
@@ -55,11 +55,21 @@ module.exports = {
         }
     },
 
+    fileNotFound: (file, path) => {
+        console.log(
+            color('[ERROR]', 'RED'),
+            color('File', 'WHITE'),
+            color(`${file}`, 'MAGENTA'),
+            color('not found in', 'WHITE'),
+            color(`${path}`, 'MAGENTA')
+        );
+    },
+
     help: () => {
         console.log(
             color('\nAWS Magento 2 Gulp', 'GREEN'),
             color('version', 'WHITE'),
-            color('1.4.0\n\n', 'YELLOW'),
+            color('1.4.1\n\n', 'YELLOW'),
             color('Usage:\n', 'YELLOW'),
             color('  gulp [command] --[package] --[arguments]\n\n', 'WHITE'),
             color('Avaliable commands:\n', 'YELLOW'),

--- a/dev/tools/gulp/paths.js
+++ b/dev/tools/gulp/paths.js
@@ -17,13 +17,29 @@ const devArgs = require('./constants/devArgs');
 const folders = require('./constants/folders');
 const matchTheme = require('./matchTheme');
 const themesConfig = require('../grunt/configs/local-themes');
+const loggers = require('./loggers');
 
 let cleanPaths = [];
 let criticalFiles = [];
 let deployPaths = [];
-let deployVersion = fs.readFileSync(`${folders.PUB_STATIC}/deployed_version.txt`, 'utf8');
 let execPaths = [];
 let sources = {};
+let deployVersion;
+
+try {
+    deployVersion = fs.readFileSync(`${folders.PUB_STATIC}/deployed_version.txt`, 'utf8')
+} catch (err) {
+    if (err.code === 'ENOENT') {
+        let file = 'deployed_version.txt';
+        let path = `${folders.PUB_STATIC}/`;
+
+        deployVersion = 'no-version';
+
+        loggers.fileNotFound(file, path);
+    } else {
+        throw err;
+    }
+}
 
 if (
     !args.themeName ||

--- a/dev/tools/gulp/paths.js
+++ b/dev/tools/gulp/paths.js
@@ -43,7 +43,7 @@ if (
                 criticalDest = `${folders.THEME_FOLDER}/${themesConfig[i].area}/${
                     themesConfig[i].name
                 }/${folders.CRITICAL_CSS_DEST}/`,
-                criticalAbsolutePath = `url(${folders.PUB_STATIC}/version${
+                criticalAbsolutePath = `url(${criticalConfig.url}${folders.PUB_STATIC}/version${
                     deployVersion}/${themesConfig[i].area
                 }/${themesConfig[i].name}/${themesConfig[i].locale}/`,
                 imgFiles = `${folders.THEME_FOLDER}/${themesConfig[i].area}/${themesConfig[i].name}`;
@@ -100,7 +100,7 @@ if (
         criticalDest = `${folders.THEME_FOLDER}/${themesConfig[args.themeName].area}/${
             themesConfig[args.themeName].name
         }/${folders.CRITICAL_CSS_DEST}/`,
-        criticalAbsolutePath = `url(${folders.PUB_STATIC}/version${deployVersion}/${
+        criticalAbsolutePath = `url(${criticalConfig.url}${folders.PUB_STATIC}/version${deployVersion}/${
             themesConfig[args.themeName].area
         }/${themesConfig[args.themeName].name}/${themesConfig[args.themeName].locale}/`;
 

--- a/package.json.sample-aws
+++ b/package.json.sample-aws
@@ -1,6 +1,6 @@
 {
     "name": "magento-2-gulp",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "private": true,
     "author": "Absolute Web Services",
     "description": "Magento 2 node modules dependencies",


### PR DESCRIPTION
Hi, @elisei!
Sorry for the late reply.

> using "/pub" in urls is not correct. You need 2 calls to the same file when the css is loaded.

The browser will cache the image (for example) the first time it loads, so any subsequent use of the same image will be loaded from the cache instead of from the server.
And I don't  understand how to avoid `pub/` if we have it in our static files path on each page.

> In addition, the absolute path can cause problems for stores that do not use ssl in all requests (which is not my case).

I think we can move this config to `local.js`
```
module.exports = {
    hostname: 'hostname',
    generic: 'loc',
    useHttp2: true
};
```